### PR TITLE
Use Flexbox instead of inline-block for layout and sidebar

### DIFF
--- a/src/components/Elements/Basic.tsx
+++ b/src/components/Elements/Basic.tsx
@@ -15,6 +15,7 @@ const buildDataAttributes = (attributes: BuildDataAttributesSettings = {}) => {
 };
 
 interface Props {
+  id?: string;
   classes?: string[];
   dataSet: BuildDataAttributesSettings;
   end: Date;
@@ -22,12 +23,15 @@ interface Props {
   style?: CSSProperties;
   title: string;
   tooltip?: ReactNode;
+  altId?: string;
 }
 
 const Basic: FunctionComponent<Props> = (props) => {
-  const { classes = [], dataSet, end, start, style, title, tooltip } = props;
+  const { classes = [], dataSet, end, start, style, title, tooltip, altId, id } = props;
   return (
     <div
+      id={id}
+      data-altId={altId}
       className={createClasses("rt-element", classes)}
       style={style}
       {...buildDataAttributes(dataSet)}

--- a/src/components/Timeline/Tracks/Element.tsx
+++ b/src/components/Timeline/Tracks/Element.tsx
@@ -4,6 +4,7 @@ import { TimeSettings } from "../../../types";
 import BasicElement from "../../Elements/Basic";
 
 interface Props {
+  id?: string;
   time?: TimeSettings;
   style?: CSSProperties;
   title?: string;
@@ -12,6 +13,7 @@ interface Props {
   classes?: string[];
   dataSet?: Record<string, string>;
   tooltip?: ReactNode;
+  altId?: string;
   clickElement?: (props: Props) => void;
 }
 
@@ -19,6 +21,7 @@ export type ClickElementHandler = (props: Props) => void;
 
 const Element: FunctionComponent<Props> = (props) => {
   const {
+    id,
     time,
     style,
     title = "",
@@ -27,6 +30,7 @@ const Element: FunctionComponent<Props> = (props) => {
     classes,
     dataSet = {},
     tooltip,
+    altId,
     clickElement,
   } = props;
 
@@ -47,6 +51,7 @@ const Element: FunctionComponent<Props> = (props) => {
       onClick={clickElement && handleClick}
     >
       <BasicElement
+        id={id}
         title={title}
         start={start}
         end={end}
@@ -54,6 +59,7 @@ const Element: FunctionComponent<Props> = (props) => {
         classes={classes}
         dataSet={dataSet}
         tooltip={tooltip}
+        altId={altId}
       />
     </div>
   );

--- a/src/components/Timeline/Tracks/Track.tsx
+++ b/src/components/Timeline/Tracks/Track.tsx
@@ -22,13 +22,14 @@ const Track: FunctionComponent<Props> = (props) => {
       <div className="rt-track__elements">
         {elements
           .filter(({ start, end }) => end > start)
-          .map((element) => {
+          .map((element: ElementInterface) => {
             const {
               classes,
               clickElement: elementClickElement,
               dataSet,
               end,
               id,
+              altId,
               start,
               style,
               time: elementTime,
@@ -49,6 +50,8 @@ const Track: FunctionComponent<Props> = (props) => {
                 time={selectedTime}
                 title={title}
                 tooltip={tooltip}
+                id={id}
+                altId={altId}
               />
             );
           })}

--- a/src/scss/components/_layout.scss
+++ b/src/scss/components/_layout.scss
@@ -4,7 +4,8 @@
   @media (min-width: $react-timelines-auto-open-breakpoint) {
     margin-left: 0;
   }
-
+  display: flex;
+  width:100%;
   &.rt-is-open {
     margin-left: 0;
   }
@@ -13,15 +14,13 @@
 .rt-layout__side {
   position: relative;
   z-index: 2;
-  display: inline-block;
-  width: $react-timelines-sidebar-width;
+
   vertical-align: top;
 }
 
 .rt-layout__main {
-  display: inline-block;
-  width: calc(100% - #{$react-timelines-sidebar-width});
   vertical-align: top;
+  flex-grow: 1;
 }
 
 .rt-layout__timeline {

--- a/src/scss/components/_track-key.scss
+++ b/src/scss/components/_track-key.scss
@@ -15,6 +15,7 @@
 .rt-track-keys > .rt-track-key >
 .rt-track-key__entry {
   padding-left: $react-timelines-sidebar-key-indent-width;
+  padding-right: $react-timelines-sidebar-key-indent-width;
 }
 
 .rt-track-keys > .rt-track-key >

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface Element {
   dataSet?: Record<string, string>;
   end: Date;
   id: string;
+  altId: string;
   start: Date;
   style: CSSProperties;
   time: TimeSettings;


### PR DESCRIPTION
Allows for the sidebar and grid to be positioned via flex instead of display:inline-block.  Using flex we can grow the grid dynamically instead of setting the sidebar to a fixed width and then trying to use `calc` to determine the grid.