### PR TITLE
fix: remove grey spacing timebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.4.1] - 2023-03-06
+
+### Fixed
+
+* Removed gray spacing between lines in Timebar
+
 ## [1.4.0] - 2023-02-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandonramsey/react-timelines-modern",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandonramsey/react-timelines-modern",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "React Timelines: Modern Implementation",
   "main": "lib/src/index.js",
   "scripts": {

--- a/src/scss/components/_timebar.scss
+++ b/src/scss/components/_timebar.scss
@@ -1,7 +1,3 @@
-.rt-timebar {
-  background-color: $react-timelines-keyline-color;
-}
-
 .rt-timebar__row {
   position: relative;
   height: $react-timelines-header-row-height + $react-timelines-border-width;


### PR DESCRIPTION
Snapshot of what changes to the grid looks like:

![image](https://user-images.githubusercontent.com/30556826/222317719-4c30cd55-5148-4780-b0ba-910e78207dc3.png)
