### PR TITLE
Update element with by date calc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.0] - 2023-03-14
+
+### Changed
+
+* Element width is now bound by timeline width
+
 ## [1.4.1] - 2023-03-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandonramsey/react-timelines-modern",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandonramsey/react-timelines-modern",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "React Timelines: Modern Implementation",
   "main": "lib/src/index.js",
   "scripts": {

--- a/src/components/Timeline/Tracks/Element.tsx
+++ b/src/components/Timeline/Tracks/Element.tsx
@@ -2,7 +2,7 @@ import { CSSProperties, FunctionComponent, ReactNode } from "react";
 import { TimeSettings } from "../../../types";
 
 import BasicElement from "../../Elements/Basic";
-
+import { getMaxDate, getMinDate } from "../../../utils/date";
 interface Props {
   id?: string;
   time?: TimeSettings;
@@ -43,7 +43,14 @@ const Element: FunctionComponent<Props> = (props) => {
       clickElement(props);
     }
   };
-  const styleLeftAndWidth = time ? time.toStyleLeftAndWidth(start, end) : {};
+
+  const styleLeftAndWidth = time
+  ? time.toStyleLeftAndWidth(
+      getMaxDate(start, time.start),
+      getMinDate(end, time.end)
+    )
+  : {};
+
   const elementStyle = {
     ...styleLeftAndWidth,
     ...(clickElement ? { cursor: "pointer" } : {}),

--- a/src/components/Timeline/Tracks/Track.test.tsx
+++ b/src/components/Timeline/Tracks/Track.test.tsx
@@ -36,6 +36,7 @@ describe("<Track />", () => {
       elements: [
         {
           id: "1",
+          altId: "1",
           start: new Date("2017-01-01"),
           end: new Date("2018-01-01"),
           style: {},
@@ -48,6 +49,7 @@ describe("<Track />", () => {
         },
         {
           id: "2",
+          altId: "2",
           start: new Date("2018-01-01"),
           end: new Date("2017-01-01"),
           style: {},

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,16 @@
+import { getMaxDate, getMinDate } from './date';
+
+describe("date", () => {
+  const d1 = new Date('2000')
+  const d2 = new Date('2022')
+  describe("getMaxDate", () => {
+    it("should return d2", () => {
+      expect(getMaxDate(d1, d2)).toBe(d2);
+    });
+  });
+  describe("getMinDate", () => {
+    it("should return d1", () => {
+      expect(getMinDate(d1, d2)).toBe(d1);
+    });
+  });
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,2 @@
+export const getMaxDate = (d1: Date, d2: Date) => d1 > d2 ? d1 : d2;
+export const getMinDate = (d1: Date, d2: Date) => d1 < d2 ? d1 : d2;


### PR DESCRIPTION
This pr will bound the elements to the width of the timeline.
Since navigating to prev/next will redraw the grid the element is correctly displayed.
Since overflow placement is no longer possible, handling children of the element component is more manageable.

![Screen Shot 2023-03-09 at 10 30 46 PM](https://user-images.githubusercontent.com/5060985/224240823-4f605a0a-e89a-4a46-a10e-919176b7ef5c.png)
![Screen Shot 2023-03-09 at 10 32 01 PM](https://user-images.githubusercontent.com/5060985/224240977-546189df-a8a4-4cff-ad57-859e4486b951.png)

