### PR TITLE
feat: modify default tooltip, enable cursor following

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,6 +9,9 @@ const config: Config = {
   rootDir: "./src",
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: [ "../jestSetup.ts" ],
+  moduleNameMapper: {
+    "\\.(css)$": "identity-obj-proxy"
+}
 }
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3171,6 +3171,12 @@
       "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
       "dev": true
     },
+    "harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3328,6 +3334,15 @@
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ignore": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -506,6 +506,19 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@floating-ui/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.6.tgz",
+      "integrity": "sha512-02vxFDuvuVPs22iJICacezYJyf7zwwOCWkPNkWNBr1U0Qt1cKFYzWvxts0AmqcOQGwt/3KJWcWIgtbUU38keyw==",
+      "requires": {
+        "@floating-ui/core": "^1.2.6"
+      }
+    },
     "@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -1806,6 +1819,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -5248,6 +5266,15 @@
         "prop-types": "^15.6.2",
         "react-is": "^16.8.6",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-tooltip": {
+      "version": "5.10.6",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.10.6.tgz",
+      "integrity": "sha512-eYxJsP4H/u0eD6key23rZB80mT2xPy8ehu9CgrXuqZT6+ol7HY1Zx7G31xS6nDzwlQs4vFLd6v1muZ1luPie+w==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.0",
+        "classnames": "^2.3.0"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "license": "MIT",
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.14.0"
+    "react": "^16.14.0",
+    "react-tooltip": "^5.10.6"
   },
   "files": [
     "lib"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^27.1.4",
     "eslint-plugin-prettier": "^4.2.1",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.2.2",
     "jest-environment-jsdom": "^29.3.1",
     "node-sass": "^7.0.3",

--- a/src/components/Elements/Basic.test.tsx
+++ b/src/components/Elements/Basic.test.tsx
@@ -34,6 +34,12 @@ describe("<Basic />", () => {
       expect(getTooltip(wrapper).html()).toMatch("Test tooltip");
     });
 
+    it('should apply style to tooltip', () => {
+      const props = { ...defaultProps, tooltipStyle: { backgroundColor: 'orange' } };
+      const wrapper = shallow(<Basic {...props} />);
+      expect(wrapper.find('.rt-element__tooltip').prop('style')).toHaveProperty('backgroundColor', 'orange');
+    });
+
     it("handles multiline tooltips", () => {
       const tooltip = "Test\ntooltip";
       const props = { ...defaultProps, tooltip };

--- a/src/components/Elements/Basic.test.tsx
+++ b/src/components/Elements/Basic.test.tsx
@@ -37,14 +37,14 @@ describe("<Basic />", () => {
     it('should apply style to tooltip', () => {
       const props = { ...defaultProps, tooltipStyle: { backgroundColor: 'orange' } };
       const wrapper = shallow(<Basic {...props} />);
-      expect(wrapper.find('.rt-element__tooltip').prop('style')).toHaveProperty('backgroundColor', 'orange');
+      expect(wrapper.find("#rt-tooltip").prop("style")).toHaveProperty("backgroundColor", "orange");
     });
 
     it("handles multiline tooltips", () => {
       const tooltip = "Test\ntooltip";
       const props = { ...defaultProps, tooltip };
       const wrapper = shallow(<Basic {...props} />);
-      expect(getTooltip(wrapper).html()).toMatch("Test<br>tooltip");
+      expect(getTooltip(wrapper).html()).toMatch("Test\ntooltip");
     });
 
     /* @todo: fix and enable this test */

--- a/src/components/Elements/Basic.tsx
+++ b/src/components/Elements/Basic.tsx
@@ -24,6 +24,7 @@ interface Props {
   title: string;
   titleStyle?: CSSProperties;
   tooltip?: ReactNode;
+  tooltipStyle?: CSSProperties;
   altId?: string;
   continuing?: ReactNode;
 }
@@ -39,6 +40,7 @@ const Basic: FunctionComponent<Props> = (props) => {
     title,
     titleStyle,
     tooltip,
+    tooltipStyle = {},
     altId,
     continuing,
   } = props;
@@ -54,7 +56,7 @@ const Basic: FunctionComponent<Props> = (props) => {
         <span className="rt-element__title" style={titleStyle}>{title}</span>
         {continuing || <></>}
       </div>
-      <div className="rt-element__tooltip">
+      <div className="rt-element__tooltip" style={tooltipStyle}>
         {tooltip || (
           <div>
             <div>{title}</div>

--- a/src/components/Elements/Basic.tsx
+++ b/src/components/Elements/Basic.tsx
@@ -48,6 +48,15 @@ const Basic: FunctionComponent<Props> = (props) => {
     altId,
     continuing,
   } = props;
+
+  const defaultTooltipStyle: CSSProperties = {
+    color: "white",
+    lineHeight: "1.3",
+    textAlign: "left",
+    padding: "10px",
+    background: "#4c4c4c",
+  };
+
   return (
     <div
       id={id}
@@ -61,12 +70,15 @@ const Basic: FunctionComponent<Props> = (props) => {
         <span className="rt-element__title" style={titleStyle}>{title}</span>
         {continuing || <></>}
       </div>
-      {tooltip || (
+      {tooltip ? (
+        <div className="rt-element__tooltip" style={tooltipStyle}>
+          {tooltip}
+        </div>
+      ) : (
         <Tooltip
-          className={tooltipStyle ? "" : "rt-element__tooltip"}
           id="rt-tooltip"
           float={tooltipFollowCursor}
-          style={tooltipStyle}
+          style={{ ...defaultTooltipStyle, ...tooltipStyle }}
           noArrow={true}
           place="top"
           offset={25}

--- a/src/components/Elements/Basic.tsx
+++ b/src/components/Elements/Basic.tsx
@@ -1,6 +1,8 @@
 import { CSSProperties, FunctionComponent, ReactNode } from "react";
 import { getDayMonth } from "../../utils/formatDate";
 import createClasses from "../../utils/classes";
+import { Tooltip } from "react-tooltip";
+import "react-tooltip/dist/react-tooltip.css";
 
 interface BuildDataAttributesSettings {
   [key: string]: string;
@@ -25,6 +27,7 @@ interface Props {
   titleStyle?: CSSProperties;
   tooltip?: ReactNode;
   tooltipStyle?: CSSProperties;
+  tooltipFollowCursor?: boolean;
   altId?: string;
   continuing?: ReactNode;
 }
@@ -41,6 +44,7 @@ const Basic: FunctionComponent<Props> = (props) => {
     titleStyle,
     tooltip,
     tooltipStyle = {},
+    tooltipFollowCursor,
     altId,
     continuing,
   } = props;
@@ -50,25 +54,34 @@ const Basic: FunctionComponent<Props> = (props) => {
       data-altid={altId}
       className={createClasses("rt-element", classes)}
       style={style}
+      data-tooltip-id="rt-tooltip"
       {...buildDataAttributes(dataSet)}
     >
       <div className="rt-element__content" aria-hidden="true">
         <span className="rt-element__title" style={titleStyle}>{title}</span>
         {continuing || <></>}
       </div>
-      <div className="rt-element__tooltip" style={tooltipStyle}>
-        {tooltip || (
+      {tooltip || (
+        <Tooltip
+          className={tooltipStyle ? "" : "rt-element__tooltip"}
+          id="rt-tooltip"
+          float={tooltipFollowCursor}
+          style={tooltipStyle}
+          noArrow={true}
+          place="top"
+          offset={25}
+          delayShow={300}
+          delayHide={300}
+        >
+          <div>{title}</div>
           <div>
-            <div>{title}</div>
-            <div>
-              <strong>Start</strong> {getDayMonth(start)}
-            </div>
-            <div>
-              <strong>End</strong> {getDayMonth(end)}
-            </div>
+            <strong>Start</strong> {getDayMonth(start)}
           </div>
-        )}
-      </div>
+          <div>
+            <strong>End</strong> {getDayMonth(end)}
+          </div>
+        </Tooltip>
+      )}
     </div>
   );
 };

--- a/src/components/Timeline/Tracks/Element.tsx
+++ b/src/components/Timeline/Tracks/Element.tsx
@@ -14,6 +14,7 @@ interface Props {
   classes?: string[];
   dataSet?: Record<string, string>;
   tooltip?: ReactNode;
+  tooltipStyle?: CSSProperties;
   altId?: string;
   clickElement?: (props: Props) => void;
   continuing?: ReactNode;
@@ -33,6 +34,7 @@ const Element: FunctionComponent<Props> = (props) => {
     classes,
     dataSet = {},
     tooltip,
+    tooltipStyle = {},
     altId,
     clickElement,
     continuing,
@@ -71,6 +73,7 @@ const Element: FunctionComponent<Props> = (props) => {
         classes={classes}
         dataSet={dataSet}
         tooltip={tooltip}
+        tooltipStyle={tooltipStyle}
         altId={altId}
         continuing={continuing}
       />

--- a/src/components/Timeline/Tracks/Element.tsx
+++ b/src/components/Timeline/Tracks/Element.tsx
@@ -15,6 +15,7 @@ interface Props {
   dataSet?: Record<string, string>;
   tooltip?: ReactNode;
   tooltipStyle?: CSSProperties;
+  tooltipFollowCursor?: boolean;
   altId?: string;
   clickElement?: (props: Props) => void;
   continuing?: ReactNode;
@@ -34,6 +35,7 @@ const Element: FunctionComponent<Props> = (props) => {
     classes,
     dataSet = {},
     tooltip,
+    tooltipFollowCursor,
     tooltipStyle = {},
     altId,
     clickElement,
@@ -73,6 +75,7 @@ const Element: FunctionComponent<Props> = (props) => {
         classes={classes}
         dataSet={dataSet}
         tooltip={tooltip}
+        tooltipFollowCursor={tooltipFollowCursor}
         tooltipStyle={tooltipStyle}
         altId={altId}
         continuing={continuing}

--- a/src/components/Timeline/Tracks/Track.tsx
+++ b/src/components/Timeline/Tracks/Track.tsx
@@ -36,6 +36,7 @@ const Track: FunctionComponent<Props> = (props) => {
               title,
               titleStyle,
               tooltip,
+              tooltipStyle,
               continuing,
             } = element;
             const selectedTime = elementTime || time;
@@ -53,6 +54,7 @@ const Track: FunctionComponent<Props> = (props) => {
                 title={title}
                 titleStyle={titleStyle}
                 tooltip={tooltip}
+                tooltipStyle={tooltipStyle}
                 id={id}
                 altId={altId}
                 continuing={continuing}

--- a/src/components/Timeline/Tracks/Track.tsx
+++ b/src/components/Timeline/Tracks/Track.tsx
@@ -36,6 +36,7 @@ const Track: FunctionComponent<Props> = (props) => {
               title,
               titleStyle,
               tooltip,
+              tooltipFollowCursor,
               tooltipStyle,
               continuing,
             } = element;
@@ -55,6 +56,7 @@ const Track: FunctionComponent<Props> = (props) => {
                 titleStyle={titleStyle}
                 tooltip={tooltip}
                 tooltipStyle={tooltipStyle}
+                tooltipFollowCursor={tooltipFollowCursor}
                 id={id}
                 altId={altId}
                 continuing={continuing}

--- a/src/scss/components/_element.scss
+++ b/src/scss/components/_element.scss
@@ -43,10 +43,3 @@
     content: ' ';
   }
 }
-
-.rt-element:hover > .rt-element__tooltip,
-.rt-element:focus > .rt-element__tooltip {
-  $delay: 0.3s;
-  transform: translateX(-50%) scale(1);
-  transition: transform 0s $delay;
-}

--- a/src/scss/components/_element.scss
+++ b/src/scss/components/_element.scss
@@ -43,3 +43,10 @@
     content: ' ';
   }
 }
+
+.rt-element:hover > .rt-element__tooltip,
+.rt-element:focus > .rt-element__tooltip {
+  $delay: 0.3s;
+  transform: translateX(-50%) scale(1);
+  transition: transform 0s $delay;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface Element {
   time: TimeSettings;
   title: string;
   tooltip?: ReactNode;
+  tooltipStyle?: CSSProperties;
   continuing?: ReactNode;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface Element {
   time: TimeSettings;
   title: string;
   tooltip?: ReactNode;
+  tooltipFollowCursor?: boolean;
   tooltipStyle?: CSSProperties;
   continuing?: ReactNode;
 }


### PR DESCRIPTION
Modified the default tooltip to use `react-tooltip` mainly in order to enable cursor following.