### PR TITLE
Give the default tooltip a unique id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.6.1] - 2023-04-18
+
+### Fixed
+
+* Give a unique identifier to the default tooltip to resolve broken test
+
 ## [1.6.0] - 2023-04-18
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1198,6 +1198,12 @@
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "17.0.17",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
@@ -5484,6 +5490,12 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -6300,10 +6312,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandonramsey/react-timelines-modern",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandonramsey/react-timelines-modern",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "React Timelines: Modern Implementation",
   "main": "lib/src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
-    "react-tooltip": "^5.10.6"
+    "react-tooltip": "^5.10.6",
+    "uuid": "^9.0.0"
   },
   "files": [
     "lib"
@@ -57,6 +58,7 @@
     "@types/jest": "^29.2.2",
     "@types/react": "^16.14.32",
     "@types/react-dom": "^18.0.8",
+    "@types/uuid": "^9.0.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^8.25.0",

--- a/src/components/Elements/Basic.test.tsx
+++ b/src/components/Elements/Basic.test.tsx
@@ -35,9 +35,9 @@ describe("<Basic />", () => {
     });
 
     it('should apply style to tooltip', () => {
-      const props = { ...defaultProps, tooltipStyle: { backgroundColor: 'orange' } };
+      const props = { ...defaultProps, tooltip: "Test Tooltip", tooltipStyle: { backgroundColor: 'orange' } };
       const wrapper = shallow(<Basic {...props} />);
-      expect(wrapper.find("#rt-tooltip").prop("style")).toHaveProperty("backgroundColor", "orange");
+      expect(getTooltip(wrapper).prop("style")).toHaveProperty("backgroundColor", "orange");
     });
 
     it("handles multiline tooltips", () => {

--- a/src/components/Elements/Basic.tsx
+++ b/src/components/Elements/Basic.tsx
@@ -2,6 +2,7 @@ import { CSSProperties, FunctionComponent, ReactNode } from "react";
 import { getDayMonth } from "../../utils/formatDate";
 import createClasses from "../../utils/classes";
 import { Tooltip } from "react-tooltip";
+import { v4 as uuidv4 } from 'uuid';
 import "react-tooltip/dist/react-tooltip.css";
 
 interface BuildDataAttributesSettings {
@@ -57,7 +58,7 @@ const Basic: FunctionComponent<Props> = (props) => {
     background: "#4c4c4c",
   };
 
-  const tooltipId = `rt-tooltip-${altId ?? Math.floor(Math.random())}`;
+  const tooltipId = `rt-tooltip-${altId ?? uuidv4()}`;
 
   return (
     <div

--- a/src/components/Elements/Basic.tsx
+++ b/src/components/Elements/Basic.tsx
@@ -57,13 +57,15 @@ const Basic: FunctionComponent<Props> = (props) => {
     background: "#4c4c4c",
   };
 
+  const tooltipId = `rt-tooltip-${altId ?? Math.floor(Math.random())}`;
+
   return (
     <div
       id={id}
       data-altid={altId}
       className={createClasses("rt-element", classes)}
       style={style}
-      data-tooltip-id="rt-tooltip"
+      data-tooltip-id={tooltipId}
       {...buildDataAttributes(dataSet)}
     >
       <div className="rt-element__content" aria-hidden="true">
@@ -76,7 +78,7 @@ const Basic: FunctionComponent<Props> = (props) => {
         </div>
       ) : (
         <Tooltip
-          id="rt-tooltip"
+          id={tooltipId}
           float={tooltipFollowCursor}
           style={{ ...defaultTooltipStyle, ...tooltipStyle }}
           noArrow={true}


### PR DESCRIPTION
Oops, using just `rt-tooltip` as the id applied to all elements on the timeline, so if there was more than one, all the tooltips would show up and overlap each other.